### PR TITLE
Add 'ctx' type to hashmap-related modules.

### DIFF
--- a/lib/github.com/diku-dk/containers/array_test.fut
+++ b/lib/github.com/diku-dk/containers/array_test.fut
@@ -9,17 +9,18 @@ import "array"
 module i64_key = {
   type i = u64
   type k = i64
+  type ctx = ()
 
   def m : i64 = 1
 
-  def hash (a: [m]u64) (x: i64) : i64 =
+  def hash _ (a: [m]u64) (x: i64) : i64 =
     let x = i64.u64 a[0] * x
     let x = (x ^ (x >> 30)) * (i64.u64 0xbf58476d1ce4e5b9)
     let x = (x ^ (x >> 27)) * (i64.u64 0x94d049bb133111eb)
     let y = (x ^ (x >> 31))
     in y
 
-  def eq : i64 -> i64 -> bool = (==)
+  def eq _ : i64 -> i64 -> bool = (==)
 }
 
 module engine = xorshift128plus
@@ -56,7 +57,7 @@ local
 def count_occourences [n] (arr: [n]i64) : [](i64, i64) =
   replicate n 1
   |> zip arr
-  |> array.reduce_by_key seed (+) 0i64
+  |> array.reduce_by_key () seed (+) 0i64
   |> (.1)
 
 -- ==
@@ -95,7 +96,7 @@ entry test_dedup [n] [m] (arrs: [n][m]i64) : bool =
          let size = length sort_dedups
          let sort_dedups = sized size sort_dedups
          let counts =
-           array.dedup seed arr
+           array.dedup () seed arr
            |> (.1)
            |> radix_sort_int i64.num_bits i64.get_bit
            |> sized size

--- a/lib/github.com/diku-dk/containers/hashmap_test.fut
+++ b/lib/github.com/diku-dk/containers/hashmap_test.fut
@@ -9,17 +9,18 @@ import "opt"
 module i64_key = {
   type i = u64
   type k = i64
+  type ctx = ()
 
   def m : i64 = 1
 
-  def hash (a: [m]u64) (x: i64) : i64 =
+  def hash _ (a: [m]u64) (x: i64) : i64 =
     let x = i64.u64 a[0] * x
     let x = (x ^ (x >> 30)) * (i64.u64 0xbf58476d1ce4e5b9)
     let x = (x ^ (x >> 27)) * (i64.u64 0x94d049bb133111eb)
     let y = (x ^ (x >> 31))
     in y
 
-  def eq : i64 -> i64 -> bool = (==)
+  def eq _ : i64 -> i64 -> bool = (==)
 }
 
 module engine = xorshift128plus
@@ -36,8 +37,8 @@ def seed = engine.rng_from_seed [1]
 entry test_find_all n =
   let vs = map (+ 10) (iota n)
   let xs = iota n
-  let (_, h) = unlifted_hmap.from_array seed (zip xs vs)
-  let (_, h') = lifted_hmap.from_array seed (zip xs vs)
+  let (_, h) = unlifted_hmap.from_array () seed (zip xs vs)
+  let (_, h') = lifted_hmap.from_array () seed (zip xs vs)
   let v = map (from_opt (-1) <-< \x -> unlifted_hmap.lookup x h) xs
   let v' = map (from_opt (-1) <-< \x -> lifted_hmap.lookup x h') xs
   in all (\x -> unlifted_hmap.member x h) xs
@@ -53,8 +54,8 @@ entry test_find_all n =
 -- output { true }
 entry test_does_not_find n =
   let xs = iota n
-  let (_, h) = unlifted_hmap.from_array seed (zip xs (iota n))
-  let (_, h') = lifted_hmap.from_array seed (zip xs (iota n))
+  let (_, h) = unlifted_hmap.from_array () seed (zip xs (iota n))
+  let (_, h') = lifted_hmap.from_array () seed (zip xs (iota n))
   let idxs = (n..<n + 1)
   let v = map (from_opt (-1) <-< \x -> unlifted_hmap.lookup x h) idxs
   let v' = map (from_opt (-1) <-< \x -> lifted_hmap.lookup x h') idxs
@@ -69,8 +70,8 @@ entry test_does_not_find n =
 -- output { true }
 entry test_find_all_dups n =
   let xs = iota n |> map (% 10)
-  let (_, h) = unlifted_hmap.from_array seed (zip xs (iota n))
-  let (_, h') = lifted_hmap.from_array seed (zip xs (iota n))
+  let (_, h) = unlifted_hmap.from_array () seed (zip xs (iota n))
+  let (_, h') = lifted_hmap.from_array () seed (zip xs (iota n))
   in all (\x -> unlifted_hmap.member x h) xs
      && all (\x -> lifted_hmap.member x h') xs
 
@@ -81,8 +82,8 @@ entry test_find_all_dups n =
 entry test_does_not_find_dups n =
   let m = 10
   let xs = iota n |> map (% m)
-  let (_, h) = unlifted_hmap.from_array seed (zip xs (iota n))
-  let (_, h') = lifted_hmap.from_array seed (zip xs (iota n))
+  let (_, h) = unlifted_hmap.from_array () seed (zip xs (iota n))
+  let (_, h') = lifted_hmap.from_array () seed (zip xs (iota n))
   let idxs = (m..<n)
   in all (\x -> unlifted_hmap.not_member x h) idxs
      && all (\x -> lifted_hmap.not_member x h') idxs
@@ -94,8 +95,8 @@ entry test_does_not_find_dups n =
 entry test_dedup n =
   let m = 50
   let xs = iota n |> map (% m)
-  let (_, h) = unlifted_hmap.from_array seed (zip xs (iota n))
-  let (_, h') = lifted_hmap.from_array seed (zip xs (iota n))
+  let (_, h) = unlifted_hmap.from_array () seed (zip xs (iota n))
+  let (_, h') = lifted_hmap.from_array () seed (zip xs (iota n))
   let arr = unlifted_hmap.to_array h |> map (.0)
   let arr' = lifted_hmap.to_array h' |> map (.0)
   in length arr == m
@@ -111,12 +112,14 @@ entry test_hist [m] (xs: [m]i64) =
   let n = 50
   let ks = map (% n) xs
   let (_, h) =
-    unlifted_hmap.from_array_hist seed
+    unlifted_hmap.from_array_hist ()
+                                  seed
                                   (+)
                                   0
                                   (zip ks (replicate m 1i64))
   let (_, h') =
-    lifted_hmap.from_array_hist seed
+    lifted_hmap.from_array_hist ()
+                                seed
                                 (+)
                                 0
                                 (zip ks (replicate m 1i64))
@@ -134,8 +137,8 @@ entry test_hist [m] (xs: [m]i64) =
 -- output { true }
 entry test_map n =
   let xs = iota n
-  let (_, h) = unlifted_hmap.from_array seed (zip xs xs)
-  let (_, h') = lifted_hmap.from_array seed (zip xs xs)
+  let (_, h) = unlifted_hmap.from_array () seed (zip xs xs)
+  let (_, h') = lifted_hmap.from_array () seed (zip xs xs)
   let p = unlifted_hmap.hashmap_map (* 2) h |> unlifted_hmap.to_array
   let p' = lifted_hmap.hashmap_map (* 2) h' |> lifted_hmap.to_array
   in all (\(k, v) -> k * 2 == v) p
@@ -147,8 +150,8 @@ entry test_map n =
 -- output { true }
 entry test_update n =
   let xs = iota n
-  let (_, h) = unlifted_hmap.from_array seed (zip xs xs)
-  let (_, h') = lifted_hmap.from_array seed (zip xs xs)
+  let (_, h) = unlifted_hmap.from_array () seed (zip xs xs)
+  let (_, h') = lifted_hmap.from_array () seed (zip xs xs)
   let p =
     unlifted_hmap.update (zip xs (replicate n (-1))) h
     |> unlifted_hmap.to_array

--- a/lib/github.com/diku-dk/containers/hashset.fut
+++ b/lib/github.com/diku-dk/containers/hashset.fut
@@ -13,6 +13,9 @@ module type hashset = {
   -- | The key type.
   type k
 
+  -- | The context type.
+  type ctx
+
   -- | The random number generator.
   type rng
 
@@ -41,7 +44,7 @@ module type hashset = {
   -- **Expected Work:** *O(n)*
   --
   -- **Expected Span:** *O(log n)*
-  val from_array [n] : rng -> [n]k -> (rng, hashset)
+  val from_array [n] : ctx -> rng -> [n]k -> (rng, hashset)
 
   -- | Convert hashset to an array of keys.
   --
@@ -61,17 +64,20 @@ module type hashset = {
 module hashset (K: key) (E: rng_engine with int.t = K.i)
   : hashset
     with rng = E.rng
-    with k = K.k = {
+    with k = K.k
+    with ctx = K.ctx = {
   module hashset = hashset K E
   type rng = hashset.rng
   type k = hashset.k
+  type ctx = hashset.ctx
 
   type~ hashset = ?[n][w][f].hashset.hashset [n] [w] [f]
 
   def from_array [n]
+                 (ctx: ctx)
                  (r: rng)
                  (keys: [n]k) : (rng, hashset) =
-    hashset.from_array r keys
+    hashset.from_array ctx r keys
 
   def to_array (set: hashset) : []k =
     hashset.to_array set

--- a/lib/github.com/diku-dk/containers/hashset_test.fut
+++ b/lib/github.com/diku-dk/containers/hashset_test.fut
@@ -8,17 +8,18 @@ module lifted = import "hashset"
 module i64_key = {
   type i = u64
   type k = i64
+  type ctx = ()
 
   def m : i64 = 1
 
-  def hash (a: [m]u64) (x: i64) : i64 =
+  def hash () (a: [m]u64) (x: i64) : i64 =
     let x = i64.u64 a[0] * x
     let x = (x ^ (x >> 30)) * (i64.u64 0xbf58476d1ce4e5b9)
     let x = (x ^ (x >> 27)) * (i64.u64 0x94d049bb133111eb)
     let y = (x ^ (x >> 31))
     in y
 
-  def eq : i64 -> i64 -> bool = (==)
+  def eq () : i64 -> i64 -> bool = (==)
 }
 
 module engine = xorshift128plus
@@ -34,8 +35,8 @@ def seed = engine.rng_from_seed [1]
 -- output { true }
 entry test_find_all n =
   let xs = iota n
-  let (_, s) = unlifted_set.from_array seed xs
-  let (_, s') = lifted_set.from_array seed xs
+  let (_, s) = unlifted_set.from_array () seed xs
+  let (_, s') = lifted_set.from_array () seed xs
   in all (\x -> unlifted_set.member x s) xs
      && all (\x -> lifted_set.member x s') xs
 
@@ -47,8 +48,8 @@ entry test_find_all n =
 -- output { true }
 entry test_does_not_find n =
   let ys = iota n
-  let (_, s) = unlifted_set.from_array seed ys
-  let (_, s') = lifted_set.from_array seed ys
+  let (_, s) = unlifted_set.from_array () seed ys
+  let (_, s') = lifted_set.from_array () seed ys
   let idxs = (n..<n + 1)
   in all (\x -> unlifted_set.not_member x s) idxs
      && all (\x -> lifted_set.not_member x s') idxs
@@ -59,8 +60,8 @@ entry test_does_not_find n =
 -- output { true }
 entry test_find_all_dups n =
   let xs = iota n |> map (% 10)
-  let (_, s) = unlifted_set.from_array seed xs
-  let (_, s') = lifted_set.from_array seed xs
+  let (_, s) = unlifted_set.from_array () seed xs
+  let (_, s') = lifted_set.from_array () seed xs
   in all (\x -> unlifted_set.member x s) xs
      && all (\x -> lifted_set.member x s') xs
 
@@ -70,8 +71,8 @@ entry test_find_all_dups n =
 -- output { true }
 entry test_does_not_find_dups n =
   let ys = iota n |> map (% 10)
-  let (_, s) = unlifted_set.from_array seed ys
-  let (_, s') = lifted_set.from_array seed ys
+  let (_, s) = unlifted_set.from_array () seed ys
+  let (_, s') = lifted_set.from_array () seed ys
   let idxs = (10..<n)
   in all (\x -> unlifted_set.not_member x s) idxs
      && all (\x -> lifted_set.not_member x s') idxs
@@ -82,8 +83,8 @@ entry test_does_not_find_dups n =
 -- output { true }
 entry test_dedup n =
   let ys = iota n |> map (% 100)
-  let (_, s) = unlifted_set.from_array seed ys
-  let (_, s') = lifted_set.from_array seed ys
+  let (_, s) = unlifted_set.from_array () seed ys
+  let (_, s') = lifted_set.from_array () seed ys
   let arr = unlifted_set.to_array s
   let arr' = lifted_set.to_array s'
   in length arr == 100 && all (\a -> or (map (== a) (iota 100))) arr

--- a/lib/github.com/diku-dk/containers/hashset_unlifted.fut
+++ b/lib/github.com/diku-dk/containers/hashset_unlifted.fut
@@ -13,6 +13,9 @@ module type hashset = {
   -- | The key type.
   type k
 
+  -- | The context type.
+  type ctx
+
   -- | The random number generator.
   type rng
 
@@ -41,7 +44,7 @@ module type hashset = {
   -- **Expected Work:** *O(n)*
   --
   -- **Expected Span:** *O(log n)*
-  val from_array [u] : rng -> [u]k -> ?[n][f][w].(rng, hashset [n] [w] [f])
+  val from_array [u] : ctx -> rng -> [u]k -> ?[n][f][w].(rng, hashset [n] [w] [f])
 
   -- | Convert hashset to an array of keys.
   --
@@ -61,18 +64,21 @@ module type hashset = {
 module hashset (K: key) (E: rng_engine with int.t = K.i)
   : hashset
     with rng = E.rng
-    with k = K.k = {
+    with k = K.k
+    with ctx = K.ctx = {
   module hashmap = hashmap K E
   type rng = hashmap.rng
   type k = hashmap.k
+  type ctx = hashmap.ctx
 
   type hashset [n] [w] [f] =
-    hashmap.hashmap [n] [w] [f] ()
+    hashmap.hashmap ctx [n] [w] [f] ()
 
   def from_array [u]
+                 (ctx: ctx)
                  (r: rng)
                  (keys: [u]k) : ?[n][f][w].(rng, hashset [n] [w] [f]) =
-    hashmap.from_array_fill r keys ()
+    hashmap.from_array_fill ctx r keys ()
 
   def to_array [n] [w] [f] (set: hashset [n] [w] [f]) : []k =
     hashmap.to_array set

--- a/lib/github.com/diku-dk/containers/key.fut
+++ b/lib/github.com/diku-dk/containers/key.fut
@@ -4,6 +4,9 @@
 -- used in datastructures which use hash functions.
 
 module type key = {
+  -- | Context type.
+  type~ ctx
+
   -- | Constants type.
   type i
 
@@ -14,8 +17,8 @@ module type key = {
   val m : i64
 
   -- | Equality definition for the key.
-  val eq : k -> k -> bool
+  val eq : ctx -> k -> k -> bool
 
   -- | A given hash function use.
-  val hash : [m]i -> k -> i64
+  val hash : ctx -> [m]i -> k -> i64
 }

--- a/lib/github.com/diku-dk/containers/reductions_bench.fut
+++ b/lib/github.com/diku-dk/containers/reductions_bench.fut
@@ -10,17 +10,18 @@ import "hashmap"
 module i64_key = {
   type i = u64
   type k = i64
+  type ctx = ()
 
   def m : i64 = 1
 
-  def hash (a: [m]u64) (x: i64) : i64 =
+  def hash _ (a: [m]u64) (x: i64) : i64 =
     let x = i64.u64 a[0] * x
     let x = (x ^ (x >> 30)) * (i64.u64 0xbf58476d1ce4e5b9)
     let x = (x ^ (x >> 27)) * (i64.u64 0x94d049bb133111eb)
     let y = (x ^ (x >> 31))
     in y
 
-  def eq : i64 -> i64 -> bool = (==)
+  def eq _ : i64 -> i64 -> bool = (==)
 }
 
 module engine = xorshift128plus
@@ -37,7 +38,7 @@ entry replicate_i64 (n: i64) (m: i64) : [n]i64 =
 local
 entry mod_i64 (n: i64) (m: i64) : [n]i64 =
   iota n
-  |> map ((% m) <-< i64_key.hash ([1] :> [i64_key.m]u64))
+  |> map ((% m) <-< i64_key.hash () ([1] :> [i64_key.m]u64))
 
 local
 def sort_dedup [n] (arr: [n]i64) : []i64 =
@@ -81,25 +82,25 @@ def sort_count_occourences [n] (arr: [n]i64) : [](i64, i64) =
 -- script input { replicate_i64 100000000i64 1i64 }
 local
 entry bench_array_dedup [n] (arr: [n]i64) =
-  array.dedup seed arr |> (.1)
+  array.dedup () seed arr |> (.1)
 
 local
 entry bench_array_count_occourences [n] (arr: [n]i64) =
   zip arr (replicate n 1)
-  |> array.reduce_by_key seed (+) 0i64
+  |> array.reduce_by_key () seed (+) 0i64
   |> (.1)
   |> unzip
 
 local
 entry bench_hashset_dedup [n] (arr: [n]i64) =
-  hashset.from_array seed arr
+  hashset.from_array () seed arr
   |> (.1)
   |> hashset.to_array
 
 local
 entry bench_hashmap_count_occourences [n] (arr: [n]i64) =
   zip arr (replicate n 1)
-  |> hashmap.from_array_hist seed (+) 0
+  |> hashmap.from_array_hist () seed (+) 0
   |> (.1)
   |> hashmap.to_array
   |> map (.0)

--- a/strbench.fut
+++ b/strbench.fut
@@ -1,0 +1,113 @@
+import "lib/github.com/diku-dk/segmented/segmented"
+import "lib/github.com/diku-dk/containers/key"
+import "lib/github.com/diku-dk/containers/hashmap"
+import "lib/github.com/diku-dk/containers/hashset"
+import "lib/github.com/diku-dk/cpprandom/random"
+import "lib/github.com/diku-dk/sorts/radix_sort"
+
+module type slice = {
+  type elem
+  type slice
+  val mk : (i: i64) -> (n: i64) -> slice
+  val unmk : slice -> (i64, i64)
+  val get [n] : slice -> [n]elem -> ?[k].[k]elem
+}
+
+module mk_slice (E: {type elem}) : slice with elem = E.elem = {
+  type elem = E.elem
+  type slice = {i: i64, n: i64}
+  def mk i n = {i, n}
+  def unmk {i, n} = (i, n)
+  def get {i, n} xs = xs[i:i + n]
+}
+
+def arreq [n] [m] 't (eq: t -> t -> bool) (x: [n]t) (y: [m]t) =
+  n == m
+  && (loop (ok, i) = (true, 0)
+      while ok && i < n do
+        (ok && (x[i] `eq` y[i]), i + 1)).0
+
+module mk_slice_key
+  (S: slice)
+  (E: {
+    val == : S.elem -> S.elem -> bool
+    val word : S.elem -> i64
+  })
+  : key
+    with ctx = []S.elem
+    with i = u64
+    with k = S.slice = {
+  type i = u64
+  type k = S.slice
+  type~ ctx = ?[l].[l]S.elem
+
+  def m : i64 = 1
+
+  def eq (ctx: []S.elem) (x: k) (y: k) =
+    arreq (E.==) (S.get x ctx) (S.get y ctx)
+
+  def hash (ctx: []S.elem) (a: [m]u64) (x: k) : i64 =
+    loop v = 0
+    for x' in S.get x ctx do
+      let x = i64.u64 a[0] * (v ^ E.word x')
+      let x = (x ^ (x >> 30)) * (i64.u64 0xbf58476d1ce4e5b9)
+      let x = (x ^ (x >> 27)) * (i64.u64 0x94d049bb133111eb)
+      let y = (x ^ (x >> 31))
+      in y
+}
+
+module engine = xorshift128plus
+module u8slice = mk_slice {type elem = u8}
+
+module slice_key = mk_slice_key u8slice {
+  def (==) = (u8.==)
+  def word = i64.u8
+}
+
+module hashset = hashset slice_key engine
+
+def seed = engine.rng_from_seed [1]
+
+type char = u8
+
+def is_space (x: char) = x == ' '
+def isnt_space x = !(is_space x)
+
+def (&&&) f g x = (f x, g x)
+
+def words [n] (s: [n]char) =
+  segmented_scan (+) 0 (map is_space s) (map (isnt_space >-> i64.bool) s)
+  |> (id &&& rotate 1)
+  |> uncurry zip
+  |> zip (indices s)
+  |> filter (\(i, (x, y)) -> (i == n - 1 && x > 0) || x > y)
+  |> map (\(i, (x, _)) -> (i - x + 1, x))
+
+entry mkinput (s: []char) = (s, words s)
+
+entry bench_hashset_dedup [l] [k] (ctx: [l]u8) (words: [k](i64, i64)) =
+  hashset.from_array ctx seed (map (uncurry u8slice.mk) words)
+  |> (.1)
+  |> hashset.to_array
+  |> map u8slice.unmk
+  |> map (.0)
+
+entry bench_sort_dedup [l] [k] (ctx: [l]u8) (words: [k](i64, i64)) =
+  let longest_word = i32.maximum (map (i32.i64 <-< (.1)) words)
+  let get_bit j (i, n) =
+    if j < i32.i64 n * 8
+    then u8.get_bit (j % 8) ctx[i + i64.i32 j / 8]
+    else 0
+  let sorted = radix_sort (longest_word * 8) get_bit words
+  let flags =
+    map (\i ->
+           i == 0
+           || !arreq (==)
+                     (u8slice.get (uncurry u8slice.mk sorted[i - 1]) ctx)
+                     (u8slice.get (uncurry u8slice.mk sorted[i]) ctx))
+        (indices words)
+  in zip flags sorted |> filter (.0) |> map (.1.0)
+
+-- ==
+-- entry: bench_hashset_dedup bench_sort_dedup
+-- script input { mkinput ($loadbytes "words.txt") }


### PR DESCRIPTION
This can be used to implement hash tables of strings and such.