### PR TITLE
Add module `setops` with set operations

### DIFF
--- a/lib/github.com/diku-dk/containers/setops.fut
+++ b/lib/github.com/diku-dk/containers/setops.fut
@@ -58,12 +58,12 @@ module setops : setops = {
 
   def unsome 'a f (x:opt a) : a =
     match x case #some x -> x
-	    case #none -> f()
+            case #none -> f()
 
   def merge_opt 'a (f:a->a->a) (x:opt a) (y:opt a) : opt a =
     match (x,y) case (#some x,#some y) -> #some(f x y)
-		case (#none,_) -> y
-		case (_,#none) -> x
+                case (#none,_) -> y
+                case (_,#none) -> x
 
   def setop [m][n] 'a (p:i64->bool) (f: a -> i64) (mrg:a->a->a) (A:[m]a) (B:[n]a) : ?[k].[k]a =
     let c : [m+n]a = A++B
@@ -71,8 +71,8 @@ module setops : setops = {
        |> radix_sort_by_key (\(x,_) -> f x) i64.num_bits i64.get_bit
        |> map (\(x,n) -> (#some x, n))
        |> scan (\(x,n) (y,m) ->
-		  if equal_opt (\a b -> f a == f b) x y then (merge_opt mrg x y,n+m)
-		  else (y,m)) (#none,0)
+                  if equal_opt (\a b -> f a == f b) x y then (merge_opt mrg x y,n+m)
+                  else (y,m)) (#none,0)
        |> filter (\(_,n) -> p n)
        |> map (\(x,_) -> unsome (\_ -> c[0]) x)
 
@@ -89,16 +89,16 @@ module setops : setops = {
 
   def diff_by_key 't [m][n] (key:t->i64) (a:[m]t) (b:[n]t) : ?[k].[k]t =
     let xs = map (\x -> (x,1)) (elimdubs_by_key key (\x _ -> x) a) ++
-  		 map (\x -> (x,2)) (elimdubs_by_key key (\x _ -> x) b)
-	     |> radix_sort_by_key (\(x,_) -> key x) i64.num_bits i64.get_bit
+                 map (\x -> (x,2)) (elimdubs_by_key key (\x _ -> x) b)
+             |> radix_sort_by_key (\(x,_) -> key x) i64.num_bits i64.get_bit
     let sz = length xs
     let ks : [](opt t) =
       map (\i -> if i < sz-1
-		 then if key(xs[i].0) == key(xs[i+1]).0 then #none
-		      else if xs[i].1 == 1 then #some(xs[i].0)
-		      else #none
-		 else if xs[i].1 == 1 then #some(xs[i].0)
-		 else #none) (indices xs)
+                 then if key(xs[i].0) == key(xs[i+1]).0 then #none
+                      else if xs[i].1 == 1 then #some(xs[i].0)
+                      else #none
+                 else if xs[i].1 == 1 then #some(xs[i].0)
+                 else #none) (indices xs)
     in ks |> filter is_some
           |> map (unsome (\_ -> a[0]))
 
@@ -118,19 +118,19 @@ module setops : setops = {
 
   def keyb 'a 'b (key1:a->i64) (key2:b->i64) (x:beither a b) : i64 =
     match x case #left a -> key1 a
-	    case #right b -> key2 b
-	    case #both a _ -> key1 a
-	    case #noone -> -1
+            case #right b -> key2 b
+            case #both a _ -> key1 a
+            case #noone -> -1
 
   def merge 'a 'b (key1:a->i64) (key2:b->i64) (x:beither a b) (y: beither a b) : beither a b =
     match (x,y) case (#left x', #right y') -> if key1 x' == key2 y' then #both x' y'
-					      else y
-		case (_,#noone) -> x
-		case (#noone,_) -> y
-		case (_, #both _ _) -> y
-		case (#both _ _, _) -> y
-		case (#right _, _) -> y
-		case (_, #left _) -> y
+                                              else y
+                case (_,#noone) -> x
+                case (#noone,_) -> y
+                case (_, #both _ _) -> y
+                case (#both _ _, _) -> y
+                case (#right _, _) -> y
+                case (_, #left _) -> y
 
   def join_by_key [m][n] 'a 'b (key1:a->i64) (key2:b->i64) (A:[m]a) (B:[n]b) : ?[k].[k](a,b) =
     map (\x -> #left x) A ++ map (\y -> #right y) B

--- a/lib/github.com/diku-dk/containers/setops.fut
+++ b/lib/github.com/diku-dk/containers/setops.fut
@@ -8,137 +8,148 @@ local
 -- that it may not be referenced directly by name from client code.  This
 -- limitation makes it possible for the interface to be enriched by new members
 -- in future minor versions.
-
 module type setops = {
   -- | `union a b` returns the set of elements that appear in both `a` and `b`
   -- with duplicates removed. Work: O(`n`+`m`), span: O(1).
-  val union               [m][n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
+  val union [m] [n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
 
   -- | `intersect a b` returns those elements in `a` that also appears in `b` with
   -- duplicates removed. Work: O(`n`+`m`), span: O(1).
-  val intersect           [m][n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
+  val intersect [m] [n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
 
   -- | `diff a b` returns `a` with duplicates and elements from `b`
   -- removed. Work: O(`n`+`m`), span: O(1).
-  val diff                [m][n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
+  val diff [m] [n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
 
   -- | `elimdups a` returns `a` with duplicates removed. Work: O(`n`), span:
   -- O(1).
-  val elimdups               [m] : [m]i64 -> ?[k].[k]i64
+  val elimdups [m] : [m]i64 -> ?[k].[k]i64
 
   -- | `union_by_key key f a b` returns the set of elements that appear in both
   -- `a` and `b`, identified using the function key, with duplicates removed,
   -- and with the function `f` applied to elements that occur in both `a` and
   -- `b`. Work: O(`n`+`m`), span: O(1), assuming `key` and `f` have work
   -- complexity O(1).
-  val union_by_key     't [m][n] : (t->i64) -> (t->t->t) -> [m]t -> [n]t -> ?[k].[k]t
+  val union_by_key 't [m] [n] : (t -> i64) -> (t -> t -> t) -> [m]t -> [n]t -> ?[k].[k]t
 
   -- | `intersect_by_key key f a b` returns those elements in `a` that also
   -- appears in `b`, identified using the function `key`, with duplicates
   -- removed, and with the function `f` applied to the intersecting
   -- objects. Work: O(`n`+`m`), span: O(1), assuming `key` and `f` have work
   -- complexity O(1).
-  val intersect_by_key 't [m][n] : (t->i64) -> (t->t->t) -> [m]t -> [n]t -> ?[k].[k]t
+  val intersect_by_key 't [m] [n] : (t -> i64) -> (t -> t -> t) -> [m]t -> [n]t -> ?[k].[k]t
 
   -- | `diff_by_key key a b` returns `a` with duplicates and elements from `b`
   -- removed, where the function `key` is used for identifying objects. Work:
   -- O(`n`+`m`), span: O(1), assuming key has work complexity O(1).
-  val diff_by_key      't [m][n] : (t->i64) -> [m]t -> [n]t -> ?[k].[k]t
+  val diff_by_key 't [m] [n] : (t -> i64) -> [m]t -> [n]t -> ?[k].[k]t
 
   -- | `join_by_key key1 key2 a b` returns pairs of objects in `a` and `b` that
   -- agree on keys obtained with the `key1` and `key2` functions.
-  val join_by_key   'a 'b [m][n] : (a->i64) -> (b->i64) -> [m]a -> [n]b -> ?[k].[k](a,b)
+  val join_by_key 'a 'b [m] [n] : (a -> i64) -> (b -> i64) -> [m]a -> [n]b -> ?[k].[k](a, b)
 
   -- | `elimdups_by_key key f a` returns `a` with duplicates removed, identified
   -- using the function `key`, and with duplicates merged using the function
   -- `f`, which is assumed to be associative. Work: O(`n`), span: O(1), assuming
   -- `key` and `f` have work complexity O(1).
-  val elimdups_by_key     't [m] : (t->i64) -> (t->t->t) -> [m]t -> ?[k].[k]t
+  val elimdups_by_key 't [m] : (t -> i64) -> (t -> t -> t) -> [m]t -> ?[k].[k]t
 }
 
-
 module setops : setops = {
+  def unsome 'a f (x: opt a) : a =
+    match x
+    case #some x -> x
+    case #none -> f ()
 
-  def unsome 'a f (x:opt a) : a =
-    match x case #some x -> x
-            case #none -> f()
+  def merge_opt 'a (f: a -> a -> a) (x: opt a) (y: opt a) : opt a =
+    match (x, y)
+    case (#some x, #some y) -> #some (f x y)
+    case (#none, _) -> y
+    case (_, #none) -> x
 
-  def merge_opt 'a (f:a->a->a) (x:opt a) (y:opt a) : opt a =
-    match (x,y) case (#some x,#some y) -> #some(f x y)
-                case (#none,_) -> y
-                case (_,#none) -> x
+  def setop [m] [n] 'a (p: i64 -> bool) (f: a -> i64) (mrg: a -> a -> a) (A: [m]a) (B: [n]a) : ?[k].[k]a =
+    let c: [m + n]a = A ++ B
+    in map (\x -> (x, 1)) c
+       |> radix_sort_by_key (\(x, _) -> f x) i64.num_bits i64.get_bit
+       |> map (\(x, n) -> (#some x, n))
+       |> scan (\(x, n) (y, m) ->
+                  if equal_opt (\a b -> f a == f b) x y
+                  then (merge_opt mrg x y, n + m)
+                  else (y, m))
+               (#none, 0)
+       |> filter (\(_, n) -> p n)
+       |> map (\(x, _) -> unsome (\_ -> c[0]) x)
 
-  def setop [m][n] 'a (p:i64->bool) (f: a -> i64) (mrg:a->a->a) (A:[m]a) (B:[n]a) : ?[k].[k]a =
-    let c : [m+n]a = A++B
-    in map (\x -> (x,1)) c
-       |> radix_sort_by_key (\(x,_) -> f x) i64.num_bits i64.get_bit
-       |> map (\(x,n) -> (#some x, n))
-       |> scan (\(x,n) (y,m) ->
-                  if equal_opt (\a b -> f a == f b) x y then (merge_opt mrg x y,n+m)
-                  else (y,m)) (#none,0)
-       |> filter (\(_,n) -> p n)
-       |> map (\(x,_) -> unsome (\_ -> c[0]) x)
-
-  def union_by_key [m][n] 't (key:t -> i64) (mrg:t->t->t) (a:[m]t) (b:[n]t) : ?[k].[k]t =
+  def union_by_key [m] [n] 't (key: t -> i64) (mrg: t -> t -> t) (a: [m]t) (b: [n]t) : ?[k].[k]t =
     setop (<= 1) key mrg a b
 
-  def elimdups_by_key [m] 't (key:t -> i64) (mrg:t->t->t) (a:[m]t) : ?[k].[k]t =
+  def elimdups_by_key [m] 't (key: t -> i64) (mrg: t -> t -> t) (a: [m]t) : ?[k].[k]t =
     union_by_key key mrg [] a
 
-  def intersect_by_key [m][n] 't (key:t -> i64) (mrg:t->t->t) (a:[m]t) (b:[n]t) : ?[k].[k]t =
+  def intersect_by_key [m] [n] 't (key: t -> i64) (mrg: t -> t -> t) (a: [m]t) (b: [n]t) : ?[k].[k]t =
     let a = elimdups_by_key key mrg a
     let b = elimdups_by_key key mrg b
     in setop (> 1) key mrg a b
 
-  def diff_by_key 't [m][n] (key:t->i64) (a:[m]t) (b:[n]t) : ?[k].[k]t =
-    let xs = map (\x -> (x,1)) (elimdups_by_key key (\x _ -> x) a) ++
-                 map (\x -> (x,2)) (elimdups_by_key key (\x _ -> x) b)
-             |> radix_sort_by_key (\(x,_) -> key x) i64.num_bits i64.get_bit
+  def diff_by_key 't [m] [n] (key: t -> i64) (a: [m]t) (b: [n]t) : ?[k].[k]t =
+    let xs =
+      map (\x -> (x, 1)) (elimdups_by_key key (\x _ -> x) a)
+      ++ map (\x -> (x, 2)) (elimdups_by_key key (\x _ -> x) b)
+      |> radix_sort_by_key (\(x, _) -> key x) i64.num_bits i64.get_bit
     let sz = length xs
-    let ks : [](opt t) =
-      map (\i -> if i < sz-1
-                 then if key(xs[i].0) == key(xs[i+1]).0 then #none
-                      else if xs[i].1 == 1 then #some(xs[i].0)
-                      else #none
-                 else if xs[i].1 == 1 then #some(xs[i].0)
-                 else #none) (indices xs)
+    let ks: [](opt t) =
+      map (\i ->
+             if i < sz - 1
+             then if key (xs[i].0) == key (xs[i + 1]).0
+                  then #none
+                  else if xs[i].1 == 1
+                  then #some (xs[i].0)
+                  else #none
+             else if xs[i].1 == 1
+             then #some (xs[i].0)
+             else #none)
+          (indices xs)
     in ks |> filter is_some
-          |> map (unsome (\_ -> a[0]))
+       |> map (unsome (\_ -> a[0]))
 
-  def union [m][n] (a:[m]i64) (b:[n]i64) : ?[k].[k]i64 =
+  def union [m] [n] (a: [m]i64) (b: [n]i64) : ?[k].[k]i64 =
     union_by_key (\x -> x) (\x _ -> x) a b
 
-  def elimdups [m] (a:[m]i64) : ?[k].[k]i64 =
+  def elimdups [m] (a: [m]i64) : ?[k].[k]i64 =
     elimdups_by_key (\x -> x) (\x _ -> x) a
 
-  def intersect [m][n] (a:[m]i64) (b:[n]i64) : ?[k].[k]i64 =
+  def intersect [m] [n] (a: [m]i64) (b: [n]i64) : ?[k].[k]i64 =
     intersect_by_key (\x -> x) (\x _ -> x) a b
 
-  def diff [m][n] (a:[m]i64) (b:[n]i64) : ?[k].[k]i64 =
+  def diff [m] [n] (a: [m]i64) (b: [n]i64) : ?[k].[k]i64 =
     diff_by_key (\x -> x) a b
 
   type beither 'a 'b = #left a | #right b | #both a b | #noone
 
-  def keyb 'a 'b (key1:a->i64) (key2:b->i64) (x:beither a b) : i64 =
-    match x case #left a -> key1 a
-            case #right b -> key2 b
-            case #both a _ -> key1 a
-            case #noone -> -1
+  def keyb 'a 'b (key1: a -> i64) (key2: b -> i64) (x: beither a b) : i64 =
+    match x
+    case #left a -> key1 a
+    case #right b -> key2 b
+    case #both a _ -> key1 a
+    case #noone -> -1
 
-  def merge 'a 'b (key1:a->i64) (key2:b->i64) (x:beither a b) (y: beither a b) : beither a b =
-    match (x,y) case (#left x', #right y') -> if key1 x' == key2 y' then #both x' y'
-                                              else y
-                case (_,#noone) -> x
-                case (#noone,_) -> y
-                case (_, #both _ _) -> y
-                case (#both _ _, _) -> y
-                case (#right _, _) -> y
-                case (_, #left _) -> y
+  def merge 'a 'b (key1: a -> i64) (key2: b -> i64) (x: beither a b) (y: beither a b) : beither a b =
+    match (x, y)
+    case (#left x', #right y') ->
+      if key1 x' == key2 y'
+      then #both x' y'
+      else y
+    case (_, #noone) -> x
+    case (#noone, _) -> y
+    case (_, #both _ _) -> y
+    case (#both _ _, _) -> y
+    case (#right _, _) -> y
+    case (_, #left _) -> y
 
-  def join_by_key [m][n] 'a 'b (key1:a->i64) (key2:b->i64) (A:[m]a) (B:[n]b) : ?[k].[k](a,b) =
+  def join_by_key [m] [n] 'a 'b (key1: a -> i64) (key2: b -> i64) (A: [m]a) (B: [n]b) : ?[k].[k](a, b) =
     map (\x -> #left x) A ++ map (\y -> #right y) B
     |> radix_sort_by_key (keyb key1 key2) i64.num_bits i64.get_bit
     |> scan (merge key1 key2) #noone
     |> filter (\m -> match m case #both _ _ -> true case _ -> false)
-    |> map (\m -> match m case #both a b -> (a,b) case _ -> (A[0],B[0]))
+    |> map (\m -> match m case #both a b -> (a, b) case _ -> (A[0], B[0]))
 }

--- a/lib/github.com/diku-dk/containers/setops.fut
+++ b/lib/github.com/diku-dk/containers/setops.fut
@@ -1,0 +1,141 @@
+import "../sorts/radix_sort"
+import "opt"
+
+-- | Set-like operations on arrays of values interpreted as sets
+
+local
+-- | The setops module type.  This module type is declared `local`, which means
+-- that it may not be referenced directly by name from client code.  This
+-- limitation makes it possible for the interface to be enriched by new members
+-- in future minor versions.
+
+module type setops = {
+  -- | [union a b] returns the set of elements that appear in both a and b with
+  -- dublicates removed. Work: O(n+m), span: O(1).
+  val union               [m][n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
+
+  -- | [intersect a b] returns those elements in a that also appears in b with
+  -- dublicates removed. Work: O(n+m), span: O(1).
+  val intersect           [m][n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
+
+  -- | [diff a b] returns a with dublicates and elements from b removed. Work:
+  -- O(n+m), span: O(1).
+  val diff                [m][n] : [m]i64 -> [n]i64 -> ?[k].[k]i64
+
+  -- | [elimdubs a] returns a with dublicates removed. Work: O(n), span: O(1).
+  val elimdubs               [m] : [m]i64 -> ?[k].[k]i64
+
+  -- | [union_by_key key f a b] returns the set of elements that appear in both
+  -- a and b, identified using the function key, with dublicates removed, and
+  -- with the function f applied to elements that occur in both a and b. Work:
+  -- O(n+m), span: O(1), assuming key and f have work complexity O(1).
+  val union_by_key     't [m][n] : (t->i64) -> (t->t->t) -> [m]t -> [n]t -> ?[k].[k]t
+
+  -- | [intersect_by_key key f a b] returns those elements in a that also
+  -- appears in b, identified using the function key, with dublicates removed,
+  -- and with the function f applied to the intersecting objects. Work: O(n+m),
+  -- span: O(1), assuming key and f have work complexity O(1).
+  val intersect_by_key 't [m][n] : (t->i64) -> (t->t->t) -> [m]t -> [n]t -> ?[k].[k]t
+
+  -- | [diff_by_key key a b] returns a with dublicates and elements from b
+  -- removed, where the function key is used for identifying objects. Work:
+  -- O(n+m), span: O(1), assuming key has work complexity O(1).
+  val diff_by_key      't [m][n] : (t->i64) -> [m]t -> [n]t -> ?[k].[k]t
+
+  -- | [join_by_key key1 key2 a b] returns pairs of objects in a and b that
+  -- agrees on keys obtained with the key1 and key2 functions.
+  val join_by_key   'a 'b [m][n] : (a->i64) -> (b->i64) -> [m]a -> [n]b -> ?[k].[k](a,b)
+
+  -- | [elimdubs_by_key key f a] returns a with dublicates removed, identified
+  -- using the function key, and with dublicates merged using the function f,
+  -- which is assumed to be associative. Work: O(n), span: O(1), assuming key
+  -- and f have work complexity O(1).
+  val elimdubs_by_key     't [m] : (t->i64) -> (t->t->t) -> [m]t -> ?[k].[k]t
+}
+
+
+module setops : setops = {
+
+  def unsome 'a f (x:opt a) : a =
+    match x case #some x -> x
+	    case #none -> f()
+
+  def merge_opt 'a (f:a->a->a) (x:opt a) (y:opt a) : opt a =
+    match (x,y) case (#some x,#some y) -> #some(f x y)
+		case (#none,_) -> y
+		case (_,#none) -> x
+
+  def setop [m][n] 'a (p:i64->bool) (f: a -> i64) (mrg:a->a->a) (A:[m]a) (B:[n]a) : ?[k].[k]a =
+    let c : [m+n]a = A++B
+    in map (\x -> (x,1)) c
+       |> radix_sort_by_key (\(x,_) -> f x) i64.num_bits i64.get_bit
+       |> map (\(x,n) -> (#some x, n))
+       |> scan (\(x,n) (y,m) ->
+		  if equal_opt (\a b -> f a == f b) x y then (merge_opt mrg x y,n+m)
+		  else (y,m)) (#none,0)
+       |> filter (\(_,n) -> p n)
+       |> map (\(x,_) -> unsome (\_ -> c[0]) x)
+
+  def union_by_key [m][n] 't (key:t -> i64) (mrg:t->t->t) (a:[m]t) (b:[n]t) : ?[k].[k]t =
+    setop (<= 1) key mrg a b
+
+  def elimdubs_by_key [m] 't (key:t -> i64) (mrg:t->t->t) (a:[m]t) : ?[k].[k]t =
+    union_by_key key mrg [] a
+
+  def intersect_by_key [m][n] 't (key:t -> i64) (mrg:t->t->t) (a:[m]t) (b:[n]t) : ?[k].[k]t =
+    let a = elimdubs_by_key key mrg a
+    let b = elimdubs_by_key key mrg b
+    in setop (> 1) key mrg a b
+
+  def diff_by_key 't [m][n] (key:t->i64) (a:[m]t) (b:[n]t) : ?[k].[k]t =
+    let xs = map (\x -> (x,1)) (elimdubs_by_key key (\x _ -> x) a) ++
+  		 map (\x -> (x,2)) (elimdubs_by_key key (\x _ -> x) b)
+	     |> radix_sort_by_key (\(x,_) -> key x) i64.num_bits i64.get_bit
+    let sz = length xs
+    let ks : [](opt t) =
+      map (\i -> if i < sz-1
+		 then if key(xs[i].0) == key(xs[i+1]).0 then #none
+		      else if xs[i].1 == 1 then #some(xs[i].0)
+		      else #none
+		 else if xs[i].1 == 1 then #some(xs[i].0)
+		 else #none) (indices xs)
+    in ks |> filter is_some
+          |> map (unsome (\_ -> a[0]))
+
+  def union [m][n] (a:[m]i64) (b:[n]i64) : ?[k].[k]i64 =
+    union_by_key (\x -> x) (\x _ -> x) a b
+
+  def elimdubs [m] (a:[m]i64) : ?[k].[k]i64 =
+    elimdubs_by_key (\x -> x) (\x _ -> x) a
+
+  def intersect [m][n] (a:[m]i64) (b:[n]i64) : ?[k].[k]i64 =
+    intersect_by_key (\x -> x) (\x _ -> x) a b
+
+  def diff [m][n] (a:[m]i64) (b:[n]i64) : ?[k].[k]i64 =
+    diff_by_key (\x -> x) a b
+
+  type beither 'a 'b = #left a | #right b | #both a b | #noone
+
+  def keyb 'a 'b (key1:a->i64) (key2:b->i64) (x:beither a b) : i64 =
+    match x case #left a -> key1 a
+	    case #right b -> key2 b
+	    case #both a _ -> key1 a
+	    case #noone -> -1
+
+  def merge 'a 'b (key1:a->i64) (key2:b->i64) (x:beither a b) (y: beither a b) : beither a b =
+    match (x,y) case (#left x', #right y') -> if key1 x' == key2 y' then #both x' y'
+					      else y
+		case (_,#noone) -> x
+		case (#noone,_) -> y
+		case (_, #both _ _) -> y
+		case (#both _ _, _) -> y
+		case (#right _, _) -> y
+		case (_, #left _) -> y
+
+  def join_by_key [m][n] 'a 'b (key1:a->i64) (key2:b->i64) (A:[m]a) (B:[n]b) : ?[k].[k](a,b) =
+    map (\x -> #left x) A ++ map (\y -> #right y) B
+    |> radix_sort_by_key (keyb key1 key2) i64.num_bits i64.get_bit
+    |> scan (merge key1 key2) #noone
+    |> filter (\m -> match m case #both _ _ -> true case _ -> false)
+    |> map (\m -> match m case #both a b -> (a,b) case _ -> (A[0],B[0]))
+}

--- a/lib/github.com/diku-dk/containers/setops_test.fut
+++ b/lib/github.com/diku-dk/containers/setops_test.fut
@@ -1,0 +1,35 @@
+-- | ignore
+
+import "setops"
+
+-- ==
+-- entry: test_intersect
+-- input { [2i64,4i64,3i64] [4i64,6i64] } output { [4i64] }
+-- input { [2i64,4i64,3i64] empty([0]i64) } output { empty([0]i64) }
+-- input { empty([0]i64) [4i64,6i64] } output { empty([0]i64) }
+entry test_intersect (a:[]i64) (b:[]i64) : []i64 =
+  setops.intersect a b
+
+-- ==
+-- entry: test_union
+-- input { [2i64,4i64,3i64] [4i64,6i64] } output { [2i64,3i64,4i64,6i64] }
+-- input { [2i64,4i64,3i64] empty([0]i64) } output { [2i64,3i64,4i64] }
+-- input { empty([0]i64) [4i64,6i64] } output { [4i64,6i64] }
+entry test_union (a:[]i64) (b:[]i64) : []i64 =
+  setops.union a b
+
+-- ==
+-- entry: test_diff
+-- input { [2i64,4i64,3i64] [4i64,6i64] } output { [2i64,3i64] }
+-- input { [2i64,4i64,3i64] empty([0]i64) } output { [2i64,3i64,4i64] }
+-- input { empty([0]i64) [4i64,6i64] } output { empty([0]i64) }
+entry test_diff (a:[]i64) (b:[]i64) : []i64 =
+  setops.diff a b
+
+-- ==
+-- entry: test_elimdubs
+-- input { [2i64,4i64,3i64,4i64] } output { [2i64,3i64,4i64] }
+-- input { [2i64,4i64,2i64] } output { [2i64,4i64] }
+-- input { empty([0]i64) } output { empty([0]i64) }
+entry test_elimdubs (a:[]i64) : []i64 =
+  setops.elimdubs a

--- a/lib/github.com/diku-dk/containers/setops_test.fut
+++ b/lib/github.com/diku-dk/containers/setops_test.fut
@@ -7,7 +7,7 @@ import "setops"
 -- input { [2i64,4i64,3i64] [4i64,6i64] } output { [4i64] }
 -- input { [2i64,4i64,3i64] empty([0]i64) } output { empty([0]i64) }
 -- input { empty([0]i64) [4i64,6i64] } output { empty([0]i64) }
-entry test_intersect (a:[]i64) (b:[]i64) : []i64 =
+entry test_intersect (a: []i64) (b: []i64) : []i64 =
   setops.intersect a b
 
 -- ==
@@ -15,7 +15,7 @@ entry test_intersect (a:[]i64) (b:[]i64) : []i64 =
 -- input { [2i64,4i64,3i64] [4i64,6i64] } output { [2i64,3i64,4i64,6i64] }
 -- input { [2i64,4i64,3i64] empty([0]i64) } output { [2i64,3i64,4i64] }
 -- input { empty([0]i64) [4i64,6i64] } output { [4i64,6i64] }
-entry test_union (a:[]i64) (b:[]i64) : []i64 =
+entry test_union (a: []i64) (b: []i64) : []i64 =
   setops.union a b
 
 -- ==
@@ -23,7 +23,7 @@ entry test_union (a:[]i64) (b:[]i64) : []i64 =
 -- input { [2i64,4i64,3i64] [4i64,6i64] } output { [2i64,3i64] }
 -- input { [2i64,4i64,3i64] empty([0]i64) } output { [2i64,3i64,4i64] }
 -- input { empty([0]i64) [4i64,6i64] } output { empty([0]i64) }
-entry test_diff (a:[]i64) (b:[]i64) : []i64 =
+entry test_diff (a: []i64) (b: []i64) : []i64 =
   setops.diff a b
 
 -- ==
@@ -31,5 +31,5 @@ entry test_diff (a:[]i64) (b:[]i64) : []i64 =
 -- input { [2i64,4i64,3i64,4i64] } output { [2i64,3i64,4i64] }
 -- input { [2i64,4i64,2i64] } output { [2i64,4i64] }
 -- input { empty([0]i64) } output { empty([0]i64) }
-entry test_elimdups (a:[]i64) : []i64 =
+entry test_elimdups (a: []i64) : []i64 =
   setops.elimdups a

--- a/lib/github.com/diku-dk/containers/setops_test.fut
+++ b/lib/github.com/diku-dk/containers/setops_test.fut
@@ -27,9 +27,9 @@ entry test_diff (a:[]i64) (b:[]i64) : []i64 =
   setops.diff a b
 
 -- ==
--- entry: test_elimdubs
+-- entry: test_elimdups
 -- input { [2i64,4i64,3i64,4i64] } output { [2i64,3i64,4i64] }
 -- input { [2i64,4i64,2i64] } output { [2i64,4i64] }
 -- input { empty([0]i64) } output { empty([0]i64) }
-entry test_elimdubs (a:[]i64) : []i64 =
-  setops.elimdubs a
+entry test_elimdups (a:[]i64) : []i64 =
+  setops.elimdups a


### PR DESCRIPTION
... We may want to make some library renaming... For instance, there is already a file `set.fut`, which contains hashset-related functionality... Other things:

1. Some files are not modules with clear interfaces (module types). Example: `opt.fut` contains core-level declarations only... Is such a design desirable?  For `opt.fut`, I suggest we rename it to `option.fut` and have it include a module `option` with a local module type `option`.